### PR TITLE
Pass file path to nameFormatter

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = function (options) {
 
             var lessContent = [];
             
-            (function exploreJson(currentLevel, path){
+            (function exploreJson(currentLevel, path, filePath){
                 for(var key in currentLevel){
                     switch (typeof currentLevel[key]){
                         case 'object':
@@ -79,13 +79,13 @@ module.exports = function (options) {
                             break;
                         default:
                             lessContent.push('@');
-                            lessContent.push(nameFormatter(path.concat(key)));
+                            lessContent.push(nameFormatter(path.concat(key), filePath));
                             lessContent.push(': ');
                             lessContent.push(currentLevel[key]);
                             lessContent.push(';\n');
                     }
                 }
-            })(jsonContent, []);
+            })(jsonContent, [], jsonPath);
 
 
             content[i] = lessContent.join('');


### PR DESCRIPTION
This is useful when your custom `nameFormatter` needs to know which json file is being evaluated. Because I can't change the json, I need to make a modification per file:
```
            .pipe(lessJsonImport({
                nameFormatter: function(keys, jsonPath) {
                    var filename = path.parse(jsonPath).name;
                    if (filename === 'colors') keys[0] = 'color' + keys[0]; // E.g. "BlueDark" becomes "colorBlueDark" and the plugin adds the "@". Needed to preserve these var names, but we didn't want to force this on consumers of the shared colors.json
                    if (filename === 'icons') keys[0] = 'icon' + keys[0];
                    return keys;
                }
            }))
```